### PR TITLE
fix Blacklist API

### DIFF
--- a/config/apiEndpoints.ini
+++ b/config/apiEndpoints.ini
@@ -2,5 +2,5 @@
 
 ; POST request to check if userName is blacklisted
 ; params {"value": "userNameToMatch"}
-POST        /api/v1/blacklist/search        = \Controllers\Api\Blacklist->search
+POST        /api/v1/blacklist/search        = \Tirreno\Controllers\Api\Blacklist->search
 


### PR DESCRIPTION
The namespace in `app/Controllers/Api/Blacklist.php` has changed in version 0.9.11. This commit uses the modified namespace, so calling the API endpoint will trigger the correct PHP file.