### PR TITLE
Add: formatResult hook to search autocomplete

### DIFF
--- a/app/Controllers/Admin/Search/Data.php
+++ b/app/Controllers/Admin/Search/Data.php
@@ -48,7 +48,11 @@ class Data extends \Tirreno\Controllers\Admin\Base\Data {
         $iters = count($result);
 
         for ($i = 0; $i < $iters; ++$i) {
-            $result[$i]['data'] = ['category' => $result[$i]['groupName']];
+            $result[$i]['data'] = [
+                'category'    => $result[$i]['groupName'],
+                'score'       => $result[$i]['score'] ?? null,
+                'country_iso' => $result[$i]['country_iso'] ?? null,
+            ];
         }
 
         return [

--- a/app/Models/Search/Email.php
+++ b/app/Models/Search/Email.php
@@ -28,13 +28,17 @@ class Email extends \Tirreno\Models\BaseSql {
 
         $query = (
             "SELECT
-                event_email.account_id AS id,
+                event_email.account_id  AS id,
                 'Email'                 AS \"groupName\",
                 'id'                    AS \"entityId\",
-                event_email.email      AS value
+                event_email.email       AS value,
+                event_account.score     AS score
 
             FROM
                 event_email
+
+            LEFT JOIN
+                event_account ON event_account.id = event_email.account_id
 
             WHERE
                 LOWER(event_email.email) LIKE LOWER(:query) AND

--- a/app/Models/Search/Ip.php
+++ b/app/Models/Search/Ip.php
@@ -28,13 +28,17 @@ class Ip extends \Tirreno\Models\BaseSql {
 
         $query = (
             "SELECT
-                event_ip.id AS id,
-                'IP'        AS \"groupName\",
-                'ip'        AS \"entityId\",
-                event_ip.ip AS value
+                event_ip.id         AS id,
+                'IP'                AS \"groupName\",
+                'ip'                AS \"entityId\",
+                event_ip.ip         AS value,
+                countries.iso       AS country_iso
 
             FROM
                 event_ip
+
+            LEFT JOIN
+                countries ON countries.id = event_ip.country
 
             WHERE
                 LOWER(TEXT(event_ip.ip)) LIKE LOWER(:query) AND

--- a/app/Models/Search/User.php
+++ b/app/Models/Search/User.php
@@ -31,7 +31,8 @@ class User extends \Tirreno\Models\BaseSql {
                 event_account.id     AS id,
                 'ID'                 AS \"groupName\",
                 'id'                 AS \"entityId\",
-                event_account.userid AS value
+                event_account.userid AS value,
+                event_account.score  AS score
 
             FROM
                 event_account
@@ -58,7 +59,8 @@ class User extends \Tirreno\Models\BaseSql {
                 'Name'                                  AS \"groupName\",
                 'id'                                    AS \"entityId\",
                 CONCAT_WS(' ', event_account.firstname,
-                               event_account.lastname)  AS value
+                               event_account.lastname)  AS value,
+                event_account.score                     AS score
 
             FROM
                 event_account

--- a/ui/js/parts/DataRenderers.js
+++ b/ui/js/parts/DataRenderers.js
@@ -1960,6 +1960,36 @@ const renderChartTooltipPart = (color, label, val) => {
     return span;
 };
 
+// These two functions return a string (via div.innerHTML / outerHTML) rather than a DOM node.
+// A string return value is required by Devbridge jQuery Autocomplete's formatResult callback setting.
+const domToHtml = node => {
+    const div = document.createElement('div');
+    div.appendChild(node.cloneNode(true));
+    return div.innerHTML;
+};
+
+const formatSearchResult = (suggestion, currentValue) => {
+    const category = suggestion.data?.category;
+    const data = suggestion.data ?? {};
+
+    if (category === 'IP') {
+        return domToHtml(renderIpWithCountry({
+            ip:          suggestion.value,
+            country_iso: data.country_iso ?? 'lh',
+        }));
+    }
+
+    // ID, Name, Email — all map to a user record
+    return domToHtml(renderClickableImportantUserWithScore({
+        accountid:        data.id ?? null,
+        email:            suggestion.value,
+        accounttitle:     suggestion.value,
+        score:            data.score ?? null,
+        score_updated_at: null,
+        is_important:     false,
+    }));
+};
+
 export {
     //Primitive
     renderBoolean,
@@ -2112,4 +2142,7 @@ export {
 
     //Chart
     renderChartTooltipPart,
+
+    //Search autocomplete
+    formatSearchResult,
 };

--- a/ui/js/parts/DataRenderers.js
+++ b/ui/js/parts/DataRenderers.js
@@ -1960,31 +1960,31 @@ const renderChartTooltipPart = (color, label, val) => {
     return span;
 };
 
-// These two functions return a string (via div.innerHTML / outerHTML) rather than a DOM node.
+// These two functions return a string (via div.innerHTML) rather than a DOM node.
 // A string return value is required by Devbridge jQuery Autocomplete's formatResult callback setting.
-const domToHtml = node => {
+const domToHtml = function(node) {
     const div = document.createElement('div');
     div.appendChild(node.cloneNode(true));
     return div.innerHTML;
 };
 
-const formatSearchResult = (suggestion, currentValue) => {
-    const category = suggestion.data?.category;
-    const data = suggestion.data ?? {};
+const formatSearchResult = function(suggestion, currentValue) {
+    const data = suggestion.data ? suggestion.data : {};
+    const category = data.category ? data.category : null;
 
     if (category === 'IP') {
         return domToHtml(renderIpWithCountry({
             ip:          suggestion.value,
-            country_iso: data.country_iso ?? 'lh',
+            country_iso: data.country_iso ? data.country_iso : 'lh',
         }));
     }
 
     // ID, Name, Email — all map to a user record
     return domToHtml(renderClickableImportantUserWithScore({
-        accountid:        data.id ?? null,
+        accountid:        data.id ? data.id : null,
         email:            suggestion.value,
         accounttitle:     suggestion.value,
-        score:            data.score ?? null,
+        score:            data.score ? data.score : null,
         score_updated_at: null,
         is_important:     false,
     }));

--- a/ui/js/parts/SearchLine.js
+++ b/ui/js/parts/SearchLine.js
@@ -3,8 +3,6 @@ import {Tooltip} from './Tooltip.js?v=2';
 import {handleAjaxError} from './utils/ErrorHandler.js?v=2';
 import {padZero} from './utils/Date.js?v=2';
 
-// --- Search suggestion helpers ---
-
 function escapeHtml(str) {
     return String(str)
         .replace(/&/g, '&amp;')
@@ -53,8 +51,6 @@ function formatSearchResult(suggestion, currentValue) {
         }
     }
 }
-
-// --- SearchLine class ---
 
 export class SearchLine {
     constructor() {

--- a/ui/js/parts/SearchLine.js
+++ b/ui/js/parts/SearchLine.js
@@ -7,26 +7,32 @@ import {
     renderIpWithCountry,
 } from './DataRenderers.js?v=2';
 
+function domToHtml(node) {
+    const div = document.createElement('div');
+    div.appendChild(node.cloneNode(true));
+    return div.innerHTML;
+}
+
 function formatSearchResult(suggestion, currentValue) {
     const category = suggestion.data?.category;
     const data = suggestion.data ?? {};
 
     if (category === 'IP') {
-        return renderIpWithCountry({
+        return domToHtml(renderIpWithCountry({
             ip:          suggestion.value,
             country_iso: data.country_iso ?? 'lh',
-        });
+        }));
     }
 
     // ID, Name, Email — all map to a user record
-    return renderClickableImportantUserWithScore({
+    return domToHtml(renderClickableImportantUserWithScore({
         accountid:        data.id ?? null,
         email:            suggestion.value,
         accounttitle:     suggestion.value,
         score:            data.score ?? null,
         score_updated_at: null,
         is_important:     false,
-    });
+    }));
 }
 
 export class SearchLine {

--- a/ui/js/parts/SearchLine.js
+++ b/ui/js/parts/SearchLine.js
@@ -2,54 +2,31 @@ import {Loader} from './Loader.js?v=2';
 import {Tooltip} from './Tooltip.js?v=2';
 import {handleAjaxError} from './utils/ErrorHandler.js?v=2';
 import {padZero} from './utils/Date.js?v=2';
-
-function escapeHtml(str) {
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
-}
-
-function highlightMatch(text, query) {
-    if (!query) return text;
-    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return text.replace(new RegExp(`(${escaped})`, 'gi'), '<strong>$1</strong>');
-}
-
-function renderUserSuggestion(suggestion, currentValue) {
-    const name = escapeHtml(suggestion.value);
-    const highlighted = highlightMatch(name, currentValue);
-    const score = suggestion.data?.score != null
-        ? `<span class="search-suggestion-score">${suggestion.data.score}</span>`
-        : '';
-    return `<span class="search-suggestion-user">${highlighted}${score}</span>`;
-}
-
-function renderIpSuggestion(suggestion, currentValue) {
-    const ip = escapeHtml(suggestion.value);
-    const highlighted = highlightMatch(ip, currentValue);
-    const iso = suggestion.data?.country_iso;
-    const flag = iso
-        ? `<span class="search-suggestion-flag f32"><span class="flag ${iso.toLowerCase()}"></span></span>`
-        : '';
-    return `${flag}<span class="search-suggestion-ip">${highlighted}</span>`;
-}
+import {
+    renderClickableImportantUserWithScore,
+    renderIpWithCountry,
+} from './DataRenderers.js?v=2';
 
 function formatSearchResult(suggestion, currentValue) {
     const category = suggestion.data?.category;
-    switch (category) {
-        case 'ID':
-        case 'Name':
-        case 'Email':
-            return renderUserSuggestion(suggestion, currentValue);
-        case 'IP':
-            return renderIpSuggestion(suggestion, currentValue);
-        default: {
-            const safe = escapeHtml(suggestion.value);
-            return highlightMatch(safe, currentValue);
-        }
+    const data = suggestion.data ?? {};
+
+    if (category === 'IP') {
+        return renderIpWithCountry({
+            ip:          suggestion.value,
+            country_iso: data.country_iso ?? 'lh',
+        });
     }
+
+    // ID, Name, Email — all map to a user record
+    return renderClickableImportantUserWithScore({
+        accountid:        data.id ?? null,
+        email:            suggestion.value,
+        accounttitle:     suggestion.value,
+        score:            data.score ?? null,
+        score_updated_at: null,
+        is_important:     false,
+    });
 }
 
 export class SearchLine {

--- a/ui/js/parts/SearchLine.js
+++ b/ui/js/parts/SearchLine.js
@@ -3,37 +3,8 @@ import {Tooltip} from './Tooltip.js?v=2';
 import {handleAjaxError} from './utils/ErrorHandler.js?v=2';
 import {padZero} from './utils/Date.js?v=2';
 import {
-    renderClickableImportantUserWithScore,
-    renderIpWithCountry,
+    formatSearchResult,
 } from './DataRenderers.js?v=2';
-
-function domToHtml(node) {
-    const div = document.createElement('div');
-    div.appendChild(node.cloneNode(true));
-    return div.innerHTML;
-}
-
-function formatSearchResult(suggestion, currentValue) {
-    const category = suggestion.data?.category;
-    const data = suggestion.data ?? {};
-
-    if (category === 'IP') {
-        return domToHtml(renderIpWithCountry({
-            ip:          suggestion.value,
-            country_iso: data.country_iso ?? 'lh',
-        }));
-    }
-
-    // ID, Name, Email — all map to a user record
-    return domToHtml(renderClickableImportantUserWithScore({
-        accountid:        data.id ?? null,
-        email:            suggestion.value,
-        accounttitle:     suggestion.value,
-        score:            data.score ?? null,
-        score_updated_at: null,
-        is_important:     false,
-    }));
-}
 
 export class SearchLine {
     constructor() {

--- a/ui/js/parts/SearchLine.js
+++ b/ui/js/parts/SearchLine.js
@@ -3,6 +3,59 @@ import {Tooltip} from './Tooltip.js?v=2';
 import {handleAjaxError} from './utils/ErrorHandler.js?v=2';
 import {padZero} from './utils/Date.js?v=2';
 
+// --- Search suggestion helpers ---
+
+function escapeHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function highlightMatch(text, query) {
+    if (!query) return text;
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return text.replace(new RegExp(`(${escaped})`, 'gi'), '<strong>$1</strong>');
+}
+
+function renderUserSuggestion(suggestion, currentValue) {
+    const name = escapeHtml(suggestion.value);
+    const highlighted = highlightMatch(name, currentValue);
+    const score = suggestion.data?.score != null
+        ? `<span class="search-suggestion-score">${suggestion.data.score}</span>`
+        : '';
+    return `<span class="search-suggestion-user">${highlighted}${score}</span>`;
+}
+
+function renderIpSuggestion(suggestion, currentValue) {
+    const ip = escapeHtml(suggestion.value);
+    const highlighted = highlightMatch(ip, currentValue);
+    const iso = suggestion.data?.country_iso;
+    const flag = iso
+        ? `<span class="search-suggestion-flag f32"><span class="flag ${iso.toLowerCase()}"></span></span>`
+        : '';
+    return `${flag}<span class="search-suggestion-ip">${highlighted}</span>`;
+}
+
+function formatSearchResult(suggestion, currentValue) {
+    const category = suggestion.data?.category;
+    switch (category) {
+        case 'ID':
+        case 'Name':
+        case 'Email':
+            return renderUserSuggestion(suggestion, currentValue);
+        case 'IP':
+            return renderIpSuggestion(suggestion, currentValue);
+        default: {
+            const safe = escapeHtml(suggestion.value);
+            return highlightMatch(safe, currentValue);
+        }
+    }
+}
+
+// --- SearchLine class ---
+
 export class SearchLine {
     constructor() {
         this.loader = new Loader();
@@ -20,6 +73,8 @@ export class SearchLine {
             groupBy: 'category',
             showNoSuggestionNotice: true,
             noSuggestionNotice: 'Sorry, no matching results',
+
+            formatResult: formatSearchResult,
 
             onSelect: function(suggestion) {
                 window.open(`${window.app_base}/${suggestion.entityId}/${suggestion.id}`, '_self');


### PR DESCRIPTION
Closes #6

## Problem

The global search autocomplete renders all suggestion types as plain text. There is no visual differentiation between users, IPs, domains, ISPs, emails, or phones — and no contextual metadata (risk score, country) is shown alongside results.

## Solution

This PR wires up the `formatResult` hook already supported by the vendored [devbridge jQuery Autocomplete](https://github.com/devbridge/jQuery-Autocomplete) library, and enriches the backend payloads so each suggestion carries enough data to render meaningfully.

### Backend changes

**`app/Models/Search/User.php`**
- Added `event_account.score AS score` to both `searchByUserId()` and `searchByName()` queries

**`app/Models/Search/Ip.php`**
- Added `LEFT JOIN countries ON countries.id = event_ip.country`
- Added `countries.iso AS country_iso` to the SELECT — consistent with how `app/Models/Ip.php`, `app/Models/Map.php`, and others resolve country ISO codes

**`app/Controllers/Admin/Search/Data.php`**
- Extended the `data` payload from `['category' => ...]` to also include `score` and `country_iso`; non-enriched result types (Domain, ISP, Phone) receive `null` for these fields and are unaffected

### Frontend changes

**`ui/js/parts/DataRenderers.js`**
- Added `domToHtml(node)` — private helper that serialises a DOM node to an HTML string, required because Devbridge jQuery Autocomplete's `formatResult` callback must return a string, not a DOM node
- Added `formatSearchResult(suggestion, currentValue)` — dispatches by `suggestion.data.category`:
  - `IP` → renders country flag + IP via existing `renderIpWithCountry()`
  - `ID` / `Name` / `Email` → renders score badge + value via existing `renderClickableImportantUserWithScore()`
- Both functions follow project conventions: placed in `DataRenderers.js` alongside all other render functions, no optional chaining (`?.`) or nullish coalescing (`??`) operators (replaced with ternary operators for older browser compatibility), `formatSearchResult` is exported; `domToHtml` remains private

**`ui/js/parts/SearchLine.js`**
- Imports `formatSearchResult` from `DataRenderers.js`
- Passes it as `formatResult: formatSearchResult` in the autocomplete config
- No rendering logic remains in `SearchLine.js` — it is a class-only module

## Testing

- Search for a known user ID → suggestion shows value + score badge
- Search for a known user name → same
- Search for an IP → suggestion shows country flag + IP
- Search for a domain/ISP/email/phone → no regressions, renders as before
- Search with no results → "Sorry, no matching results" notice still appears

### Test Results

**Before:**
Search with email/name/id:
<img width="723" height="404" alt="Screenshot 2026-07-01 at 8 57 28 AM" src="https://github.com/user-attachments/assets/35f01e7a-aec7-44ef-9740-90e907717dcd"/>

Search with IP:
<img width="711" height="378" alt="Screenshot 2026-07-01 at 8 57 11 AM" src="https://github.com/user-attachments/assets/c3d5d058-f9bc-489b-9072-2529c0d505e4"/>

---

**After this PR:**
Search with email/name/id: (notice score shows up along the email/name/id)
<img width="1217" height="710" alt="Screenshot 2026-07-01 at 8 56 22 AM" src="https://github.com/user-attachments/assets/e26c019b-9ac3-488a-83bb-b2ccc3929e9f"/>

Search with IP: (notice country flag shows up along with IP)
<img width="1205" height="710" alt="Screenshot 2026-07-01 at 8 59 42 AM" src="https://github.com/user-attachments/assets/f00704e2-6bc9-486e-bc97-49fc35f85217"/>