### PR TITLE
Add: formatResult hook to search autocomplete

### DIFF
--- a/app/Controllers/Admin/Search/Data.php
+++ b/app/Controllers/Admin/Search/Data.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * tirreno ~ open-source security framework
+ * Copyright (c) Tirreno Technologies Sàrl (https://www.tirreno.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Tirreno Technologies Sàrl (https://www.tirreno.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.tirreno.com Tirreno(tm)
+ */
+
+declare(strict_types=1);
+
+namespace Tirreno\Controllers\Admin\Search;
+
+class Data extends \Tirreno\Controllers\Admin\Base\Data {
+    public function getSearchResults(?string $query, int $apiKey): array {
+        $result = [];
+
+        if ($query === '' || $query === null) {
+            return ['suggestions' => $result];
+        }
+
+        $model = new \Tirreno\Models\Search\Domain();
+        $result1 = $model->searchByDomain($query, $apiKey);
+
+        $model = new \Tirreno\Models\Search\Ip();
+        $result2 = $model->searchByIp($query, $apiKey);
+
+        $model = new \Tirreno\Models\Search\Isp();
+        $result3 = $model->searchByIsp($query, $apiKey);
+
+        $model = new \Tirreno\Models\Search\User();
+        $result4 = $model->searchByUserId($query, $apiKey);
+        $result5 = $model->searchByName($query, $apiKey);
+
+        $model = new \Tirreno\Models\Search\Email();
+        $result6 = $model->searchByEmail($query, $apiKey);
+
+        $model = new \Tirreno\Models\Search\Phone();
+        $result7 = $model->searchByPhone($query, $apiKey);
+
+        $result = array_merge($result1, $result2, $result3, $result4, $result5, $result6, $result7);
+        $iters = count($result);
+
+        for ($i = 0; $i < $iters; ++$i) {
+            $result[$i]['data'] = [
+                'category'    => $result[$i]['groupName'],
+                'score'       => $result[$i]['score'] ?? null,
+                'country_iso' => $result[$i]['country_iso'] ?? null,
+            ];
+        }
+
+        return [
+            'suggestions' => $result,
+        ];
+    }
+}

--- a/app/Models/Search/Email.php
+++ b/app/Models/Search/Email.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 
 namespace Tirreno\Models\Search;
 
-class Email extends \Tirreno\Models\Base {
+class Email extends \Tirreno\Models\BaseSql {
+    protected ?string $DB_TABLE_NAME = 'event_email';
+
     public function searchByEmail(string $query, int $apiKey): array {
         $params = [
             ':api_key' => $apiKey,
@@ -26,13 +28,17 @@ class Email extends \Tirreno\Models\Base {
 
         $query = (
             "SELECT
-                event_email.account_id AS id,
+                event_email.account_id  AS id,
                 'Email'                 AS \"groupName\",
                 'id'                    AS \"entityId\",
-                event_email.email      AS value
+                event_email.email       AS value,
+                event_account.score     AS score
 
             FROM
                 event_email
+
+            LEFT JOIN
+                event_account ON event_account.id = event_email.account_id
 
             WHERE
                 LOWER(event_email.email) LIKE LOWER(:query) AND

--- a/app/Models/Search/Ip.php
+++ b/app/Models/Search/Ip.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 
 namespace Tirreno\Models\Search;
 
-class Ip extends \Tirreno\Models\Base {
+class Ip extends \Tirreno\Models\BaseSql {
+    protected ?string $DB_TABLE_NAME = 'event_ip';
+
     public function searchByIp(string $query, int $apiKey): array {
         $params = [
             ':api_key' => $apiKey,
@@ -26,13 +28,17 @@ class Ip extends \Tirreno\Models\Base {
 
         $query = (
             "SELECT
-                event_ip.id AS id,
-                'IP'        AS \"groupName\",
-                'ip'        AS \"entityId\",
-                event_ip.ip AS value
+                event_ip.id         AS id,
+                'IP'                AS \"groupName\",
+                'ip'                AS \"entityId\",
+                event_ip.ip         AS value,
+                countries.iso       AS country_iso
 
             FROM
                 event_ip
+
+            LEFT JOIN
+                countries ON countries.id = event_ip.country
 
             WHERE
                 LOWER(TEXT(event_ip.ip)) LIKE LOWER(:query) AND

--- a/app/Models/Search/User.php
+++ b/app/Models/Search/User.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 
 namespace Tirreno\Models\Search;
 
-class User extends \Tirreno\Models\Base {
+class User extends \Tirreno\Models\BaseSql {
+    protected ?string $DB_TABLE_NAME = 'event_account';
+
     public function searchByUserId(string $query, int $apiKey): array {
         $params = [
             ':api_key' => $apiKey,
@@ -29,7 +31,8 @@ class User extends \Tirreno\Models\Base {
                 event_account.id     AS id,
                 'ID'                 AS \"groupName\",
                 'id'                 AS \"entityId\",
-                event_account.userid AS value
+                event_account.userid AS value,
+                event_account.score  AS score
 
             FROM
                 event_account
@@ -56,7 +59,8 @@ class User extends \Tirreno\Models\Base {
                 'Name'                                  AS \"groupName\",
                 'id'                                    AS \"entityId\",
                 CONCAT_WS(' ', event_account.firstname,
-                               event_account.lastname)  AS value
+                               event_account.lastname)  AS value,
+                event_account.score                     AS score
 
             FROM
                 event_account

--- a/ui/js/parts/DataRenderers.js
+++ b/ui/js/parts/DataRenderers.js
@@ -1,17 +1,12 @@
-import {padZero} from './utils/Date.js?v=0.10.0';
-import {Constants} from './utils/Constants.js?v=0.10.0';
+import {padZero} from './utils/Date.js?v=2';
+import {Constants} from './utils/Constants.js?v=2';
 import {
     //truncateWithHellip,
     formatKiloValue,
     getRuleClass,
     formatTime,
     openJson,
-} from './utils/String.js?v=0.10.0';
-import {
-    inArray,
-    mapKeys,
-    defined,
-} from './utils/Functions.js?v=0.10.0';
+} from './utils/String.js?v=2';
 
 const isDashboardPage = () => !!document.getElementById('most-active-users');
 
@@ -42,7 +37,7 @@ const tooltipWrap = (tooltip, value, wrap = true, wordBreak = false) => {
         result.appendChild(node);
     }
 
-    if (defined(tooltip) && tooltip !== '') {
+    if (tooltip !== null && tooltip !== undefined && tooltip !== '') {
         result.classList.add('tooltip');
         if (wordBreak) {
             result.classList.add('tooltipster-word-break');
@@ -468,7 +463,7 @@ const renderDeviceTypeSelectorItem = (classNames, data) => {
     const [value] = splitLabel(data.label);
     const innerHtml = document.createElement('span');
 
-    const deviceIsNormal = inArray(Constants.NORMAL_DEVICES, value);
+    const deviceIsNormal = Constants.NORMAL_DEVICES.includes(value);
     const deviceTypeImg = deviceIsNormal ? value : 'unknown';
     const img = document.createElement('img');
     img.src = `${window.app_base}/ui/images/icons/${deviceTypeImg}.svg`;
@@ -486,7 +481,7 @@ const renderDeviceTypeSelectorChoice = (classNames, data, itemSelectText) => {
     const [value] = splitLabel(data.label);
     const innerHtml = document.createElement('span');
 
-    const deviceIsNormal = inArray(Constants.NORMAL_DEVICES, value);
+    const deviceIsNormal = Constants.NORMAL_DEVICES.includes(value);
     const deviceTypeImg = deviceIsNormal ? value : 'unknown';
     const img = document.createElement('img');
     img.src = `${window.app_base}/ui/images/icons/${deviceTypeImg}.svg`;
@@ -591,18 +586,18 @@ const renderHttpMethod = record => {
     return renderDefaultIfEmptySpan(span);
 };
 
-const renderTotalFrameCmp = (yesterday, today, hyphenOnEmptyOld = false, hyphenOnEmptyNew = false) => {
+const renderTotalFrameCmp = (oldval, newval, hyphenOnEmptyOld = false, hyphenOnEmptyNew = false) => {
     const frag = document.createDocumentFragment();
 
-    yesterday = parseInt(yesterday, 10) || (hyphenOnEmptyOld ? renderDefaultIfEmpty(yesterday) : 0);
-    today = parseInt(today, 10) || (hyphenOnEmptyNew ? renderDefaultIfEmpty(today) : 0);
+    oldval = parseInt(oldval, 10) || (hyphenOnEmptyOld ? renderDefaultIfEmpty(oldval) : 0);
+    newval = parseInt(newval, 10) || (hyphenOnEmptyNew ? renderDefaultIfEmpty(newval) : 0);
 
     const span = document.createElement('span');
     span.className = 'addlight';
-    span.textContent = yesterday + '/';
+    span.textContent = newval + '/';
 
     frag.appendChild(span);
-    frag.appendChild(document.createTextNode(today));
+    frag.appendChild(document.createTextNode(oldval));
 
     return frag;
 };
@@ -611,7 +606,7 @@ const renderTotalFrame = (base, val) => {
     const frag = document.createDocumentFragment();
 
     if (parseInt(base, 10) > parseInt(val, 10)) {
-        const rest = (defined(base) && base > 0 && base >= val)
+        const rest = (base !== null && base !== undefined && base > 0 && base >= val)
             ? (base - val)
             : Constants.MIDLINE_HELLIP;
         const span = document.createElement('span');
@@ -663,18 +658,18 @@ const renderBoolean = (data) => {
 const renderProportion = (n, t) => {
     const number = (typeof n === 'number' && Number.isFinite(n) && n >= 0 && n <= 100)
         ? (n > 0.0 && n < 1.0 ? '<1%' : `${Math.floor(n)}%`)
-        : '\u2212';
+        : '&minus;';
     const tooltip = t ? `Last updated: ${renderDateString(t)}` : '\u2212';
 
     return tooltipWrap(tooltip, number, true);
 };
 
 const renderUserScore = record => {
-    let score = defined(record.score) ? record.score : '\u2212';
+    let score = (record.score !== null && record.score !== undefined) ? record.score : '\u2212';
     let cls = 'empty';
 
-    if (defined(record.fraud)) {
-        score = (record.fraud) ? Constants.MULTIPLICATION_SIGN : 'OK';
+    if (record.fraud !== undefined && record.fraud !== null) {
+        score = (record.fraud) ? 'X' : 'OK';
         cls = (record.fraud) ? 'low' : 'high';
     } else {
         if (score >= Constants.USER_HIGH_TRUST_SCORE_INF) {
@@ -687,10 +682,6 @@ const renderUserScore = record => {
 
         if (score >= Constants.USER_LOW_TRUST_SCORE_INF && score < Constants.USER_LOW_TRUST_SCORE_SUP) {
             cls = 'low';
-        }
-
-        if (record.added_to_review) {
-            score = '!';
         }
     }
 
@@ -864,10 +855,10 @@ const renderUserReviewedStatus = record => {
 
 const renderUserActionButtons = (record, small = true) => {
     let html;
-    if (record.addedToReview) {
+    if (record.reviewed) {
         html = getFraudLegitButtons(record, small);
     } else {
-        html = addToReviewButton(record, small);
+        html = getToBeReviewedButton(record, small);
     }
 
     return html;
@@ -929,41 +920,17 @@ const getFraudLegitButtons = (record, small = true) => {
     return div;
 };
 
-const addToReviewButton = (record, small = true) => {
+const getToBeReviewedButton = (record, small = true) => {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'reviewed button dark-loader' + ((small) ? ' is-small' : '');
     button.textContent = 'Not reviewed';
 
-    button.id = 'add-to-review-button';
-    button.setAttribute('data-type', 'add-to-review');
+    button.setAttribute('data-type', 'reviewed');
     button.setAttribute('data-user-id', record.accountid);
+    button.setAttribute('data-button-type', 'reviewedButton');
 
     return button;
-};
-
-const renderSingleRuleTile = record => {
-    const uid = defined(record.uid) ? record.uid : '';
-    const descr = defined(record.descr) ? record.descr : '';
-    const name = defined(record.name) ? record.name : '';
-
-    const span = document.createElement('span');
-    span.className = `ruleHighlight ${getRuleClass(record.score)}`;
-    span.textContent = uid;
-
-    const el = document.createTextNode('\u00A0');
-
-    let t = document.createElement('span');
-    t.className = 'ruleName';
-    t.textContent = name;
-    t = tooltipWrap(descr, t, false);
-
-    const part = document.createElement('p');
-    part.appendChild(span);
-    part.appendChild(el);
-    part.appendChild(t);
-
-    return wrapWithRuleLink(part, uid);
 };
 
 const renderScoreDetails = record => {
@@ -981,13 +948,36 @@ const renderScoreDetails = record => {
     const details = record.score_details;
 
     if (Array.isArray(details)) {
+        let uid = '';
+        let descr = '';
+        let name = '';
+        //let part = '';
+
         for (let i = 0; i < details.length; i++) {
-            const tile = renderSingleRuleTile(details[i]);
+            uid = (details[i].uid !== null && details[i].uid !== undefined) ? details[i].uid : '';
+            descr = (details[i].descr !== null && details[i].descr !== undefined) ? details[i].descr : '';
+            name = (details[i].name!== null && details[i].name !== undefined) ? details[i].name : '';
+
+            const span = document.createElement('span');
+            span.className = `ruleHighlight ${getRuleClass(details[i].score)}`;
+            span.textContent = uid;
+
+            const el = document.createTextNode('\u00A0');
+
+            let t = document.createElement('span');
+            t.className = 'ruleName';
+            t.textContent = name;
+            t = tooltipWrap(descr, t, false);
+
+            const part = document.createElement('p');
+            part.appendChild(span);
+            part.appendChild(el);
+            part.appendChild(t);
 
             if (details[i].score !== 0) {
-                frag.appendChild(tile);
+                frag.appendChild(wrapWithRuleLink(part, uid));
             } else {
-                extra.appendChild(tile);
+                extra.appendChild(wrapWithRuleLink(part, uid));
             }
         }
     }
@@ -1070,7 +1060,7 @@ const renderClickableEmail = record => {
 };
 
 const renderReputation = record => {
-    record = defined(record) ? record : {};
+    record = (record !== null && record !== undefined) ? record : {};
 
     let icon = 'reputation-none';
     let reputation = record.reputation;
@@ -1100,8 +1090,8 @@ const renderPhone = (record) => {
     const phone = record.phonenumber;
 
     if (phone) {
-        const code = !inArray(Constants.COUNTRIES_EXCEPTIONS, record.country_iso) ? record.country_iso : 'lh';
-        const tooltip = defined(record.full_country) ? record.full_country : '';
+        const code = !Constants.COUNTRIES_EXCEPTIONS.includes(record.country_iso) ? record.country_iso : 'lh';
+        const tooltip = (record.full_country !== null && record.full_country !== undefined) ? record.full_country : '';
 
         const n       = Constants.MAX_STRING_LENGTH_FOR_PHONE;
         const number  = truncateWithHellip(phone, n);
@@ -1156,8 +1146,8 @@ const renderPhoneType = record => {
 
     if (type) {
         let src = 'smartphone.svg';
-        if (inArray(Constants.PHONE_LANDLINE, type)) src = 'landline.svg';
-        if (inArray(['nonFixedVoip', 'VOIP'], type)) src = 'voip.svg';
+        if (Constants.PHONE_LANDLINE.includes(type)) src = 'landline.svg';
+        if (['nonFixedVoip', 'VOIP'].includes(type)) src = 'voip.svg';
 
         const tooltip = type.toLowerCase().replace(/_/g, ' ');
 
@@ -1290,12 +1280,12 @@ const renderClickableIp = record => {
 
 const renderIpAndFlag = (ip, record) => {
     const countryCode = record.country_iso;
-    const code = !inArray(Constants.COUNTRIES_EXCEPTIONS, countryCode) ? countryCode.toLowerCase() : 'lh';
-    const iso = defined(countryCode) ? countryCode : '';
+    const code = !Constants.COUNTRIES_EXCEPTIONS.includes(countryCode) ? countryCode.toLowerCase() : 'lh';
+    const iso = (countryCode !== null && countryCode !== undefined) ? countryCode : '';
 
     const net = record.isp_name;
-    const tooltip = (defined(net) && net !== '') ? `${iso} - ${net}` : `${iso}`;
-    const alternative = defined(record.full_country) ? record.full_country : '';
+    const tooltip = (net !== null && net !== undefined && net !== '') ? `${iso} - ${net}` : `${iso}`;
+    const alternative = (record.full_country !== null && record.full_country !== undefined) ? record.full_country : '';
 
     const frag = document.createDocumentFragment();
 
@@ -1354,7 +1344,7 @@ const renderIpType = record => {
 
     const ipType  = record.ip_type.toLowerCase().replace(' ', '_');
     let tooltip = tooltipMap[ipType];
-    tooltip = defined(tooltip) ? tooltip : record.ip_type;
+    tooltip = (tooltip !== null && tooltip !== undefined) ? tooltip : record.ip_type;
 
     const span = document.createElement('span');
     span.className = `iptype ${ipType}`;
@@ -1391,7 +1381,7 @@ const renderCidr = record => {
 };
 
 const renderAsn = record => {
-    const asn = defined(Constants.ASN_OVERRIDE[record.asn]) ? Constants.ASN_OVERRIDE[record.asn] : record.asn;
+    const asn = (Constants.ASN_OVERRIDE[record.asn] !== undefined) ? Constants.ASN_OVERRIDE[record.asn] : record.asn;
     const span = document.createElement('span');
     span.textContent = renderDefaultIfEmpty(asn);
 
@@ -1407,8 +1397,8 @@ const renderClickableAsn = record => {
 
 //Country
 const renderCountry = (code, value, tooltip) => {
-    code = !inArray(Constants.COUNTRIES_EXCEPTIONS, code) ? code : 'lh';
-    value = defined(value) ? value : '';
+    code = !Constants.COUNTRIES_EXCEPTIONS.includes(code) ? code : 'lh';
+    value = (value !== null && value !== undefined) ? value : '';
 
     const frag = document.createDocumentFragment();
 
@@ -1447,7 +1437,7 @@ const renderClickableCountry = (record, applyTooltip = true) => {
 
 const renderClickableCountryName = record => {
     const value   = record.full_country;
-    const country = defined(value) ? value : '';
+    const country = (value !== null && value !== undefined) ? value : '';
 
     const el = document.createTextNode(country);
 
@@ -1457,7 +1447,7 @@ const renderClickableCountryName = record => {
 const renderClickableCountryTruncated = record => {
     const fullValue = record.full_country;
     let value   = record.full_country;
-    value = defined(value) ? value : '';
+    value = (value !== null && value !== undefined) ? value : '';
     value = value.length <= Constants.MAX_STRING_LENGTH_FOR_TILE ? value : record.country_iso;
 
     const span = tooltipWrap(fullValue, value, true);
@@ -1530,7 +1520,7 @@ const renderAuditFieldId = (record, length = 'medium') => {
 
 const renderClickableAuditFieldId = (record, length = 'medium') => {
     let span = renderAuditFieldId(record, length);
-    const el = defined(record.id) ? wrapWithFieldIdLink(span, record) : span;
+    const el = (record.id !== null && record.id !== undefined) ? wrapWithFieldIdLink(span, record) : span;
 
     return el;
 };
@@ -1559,7 +1549,7 @@ const renderClickableUserAgentId = record => {
 };
 
 const renderDevice = record => {
-    const deviceIsNormal = inArray(Constants.NORMAL_DEVICES, record.device_name);
+    const deviceIsNormal = Constants.NORMAL_DEVICES.includes(record.device_name);
 
     const deviceTypeTooltip = record.device_name ? record.device_name : 'unknown';
     const deviceTypeImg = deviceIsNormal ? record.device_name : 'unknown';
@@ -1584,7 +1574,7 @@ const renderDevice = record => {
 
 const renderDeviceWithOs = record => {
     const deviceTypeTooltip = record.device_name ? record.device_name : 'unknown';
-    const deviceTypeImg = inArray(Constants.NORMAL_DEVICES, record.device_name) ? record.device_name : 'unknown';
+    const deviceTypeImg = Constants.NORMAL_DEVICES.includes(record.device_name) ? record.device_name : 'unknown';
 
     let os = record.os_name ? record.os_name : 'N/A';
     os += record.os_version ? ' ' + record.os_version : '';
@@ -1684,7 +1674,7 @@ const renderDomain = (record, length = 'short') => {
 
 const renderClickableDomain = (record, length = 'short') => {
     let span = renderDomain(record, length);
-    const el = defined(record.id) ? wrapWithDomainLink(span, record) : span;
+    const el = (record.id !== null && record.id !== undefined) ? wrapWithDomainLink(span, record) : span;
 
     return el;
 };
@@ -1795,13 +1785,6 @@ const renderSensorError = record => {
     return renderTextarea(s);
 };
 
-const renderRawRequestColumn = record => {
-    const raw = truncateWithHellip(record.raw, Constants.MAX_STRING_LENGTH_RAW_REQUEST, true);
-    raw.classList.add('addlight');
-
-    return raw;
-};
-
 const renderTimeMsLogbook = (record) => {
     const span = renderTimeMs(record.created);
     const tooltip = renderTimeString(record.server_time);
@@ -1809,49 +1792,29 @@ const renderTimeMsLogbook = (record) => {
     return tooltipWrap(tooltip, span, false);
 };
 
-const renderEndpoint = (record, panel = false) => {
-    const arrow = document.createElement('span');
-    arrow.textContent = (record.ip ? Constants.DOWNWARDS_ARROW : Constants.UPWARDS_ARROW) + ' ';
-    arrow.className = 'addlight';
-
-    const limit = !panel ? Constants.MAX_STRING_LENGTH_ENDPOINT : Constants.MAX_STRING_LENGTH_ENDPOINT + 10;
-
-    const endpoint = truncateWithHellip(record.endpoint, limit, true);
-
-    const frag = document.createDocumentFragment();
-
-    frag.appendChild(arrow);
-    frag.appendChild(endpoint);
-
-    return frag;
+const renderEndpoint = record => {
+    return truncateWithHellip(record.endpoint, Constants.MAX_STRING_LENGTH_ENDPOINT, true);
 };
 
 const renderJsonTextarea = value => {
     const obj = openJson(value);
     const s = (obj !== null) ? JSON.stringify(obj, null, 2) : null;
-    const width = 37;
 
-    const splitted = (s !== null) ? s.split(/\r\n|\r|\n/) : [];
-    let rows = 0;
-    for (const line of splitted) {
-        rows += Math.ceil(line.length / width);
-    }
-
+    const rows = s ? s.split(/\r\n|\r|\n/).length : 0;
     const h = rows > 24 ? 24 : (rows < 4 ? 4 : rows);
 
-    return renderTextarea(s, h, width);
+    return renderTextarea(s, h);
 };
 
-const renderErrorType = (record, panel = false) => {
+const renderErrorType = record => {
     const frag = document.createDocumentFragment();
 
     const el = document.createElement('p');
     el.className = `bullet ${record.error_value}`;
     frag.appendChild(el);
 
-    const limit = !panel ? Constants.MAX_STRING_LENGTH_ERROR_TYPE : Constants.MAX_STRING_LENGTH_ERROR_TYPE + 10;
-    const span = truncateWithHellip(record.error_name, limit, true);
-
+    const span = document.createElement('span');
+    span.textContent = record.error_name;
     frag.appendChild(span);
 
     return frag;
@@ -1872,7 +1835,7 @@ const renderMailto = record => {
 
 const currentPlanRender = (data, type, record, _meta) => {
     const value = record.sub_plan_api_calls;
-    const text = defined(value) ? value + ' API calls' : Constants.MIDLINE_HELLIP;
+    const text = (value !== null && value !== undefined) ? value + ' API calls' : Constants.MIDLINE_HELLIP;
 
     const span = document.createElement('span');
     span.textContent = text;
@@ -1882,7 +1845,7 @@ const currentPlanRender = (data, type, record, _meta) => {
 
 const currentStatusRender = (data, type, record, meta) => {
     const value = record.sub_status;
-    const text = defined(value) ? value : Constants.MIDLINE_HELLIP;
+    const text = (value !== null && value !== undefined) ? value : Constants.MIDLINE_HELLIP;
 
     const span = document.createElement('span');
     span.textContent = text;
@@ -1892,9 +1855,9 @@ const currentStatusRender = (data, type, record, meta) => {
 
 const currentUsageRender = (data, type, record, meta) => {
     let value = record.sub_calls_used;
-    const used = defined(value) ? value : Constants.MIDLINE_HELLIP;
+    const used = (value !== null && value !== undefined) ? value : Constants.MIDLINE_HELLIP;
     value = record.sub_calls_limit;
-    const limit = defined(value) ? value : Constants.MIDLINE_HELLIP;
+    const limit = (value !== null && value !== undefined) ? value : Constants.MIDLINE_HELLIP;
 
     const span = document.createElement('span');
     span.textContent = used + '/' + limit;
@@ -1904,7 +1867,7 @@ const currentUsageRender = (data, type, record, meta) => {
 
 const currentBillingEndRender = (data, type, record, meta) => {
     const value = record.sub_next_billed;
-    const text = defined(value)
+    const text = (value !== null && value !== undefined)
         ? renderDateString(value.replace('T', ' '))
         : Constants.MIDLINE_HELLIP;
 
@@ -1916,8 +1879,8 @@ const currentBillingEndRender = (data, type, record, meta) => {
 
 const updateCardButtonRender = (data, type, record, meta) => {
     const url = record.sub_update_url;
-    const token = record.tokenPresent;
-    const disabled = (defined(url) && defined(token)) ? '' : 'disabled';
+    const token = record.apiToken;
+    const disabled = (url !== null && url !== undefined && token !== null && token !== undefined) ? '' : 'disabled';
 
     const button = document.createElement('button');
     button.className = 'button is-primary';
@@ -1946,7 +1909,7 @@ const renderEnrichmentCalculation = data => {
     let sum = 0;
 
     for (const key in keys) {
-        const c = !defined(data[key]) ? 0 : data[key];
+        const c = (data[key] === undefined || data[key] === null) ? 0 : data[key];
         sum += c;
         result.push(keys[key].padEnd(16, '.') + String(c));
     }
@@ -1997,137 +1960,34 @@ const renderChartTooltipPart = (color, label, val) => {
     return span;
 };
 
-//Rules
-const renderRuleUid = record => {
-    const elem = document.createElement('a');
-    const header = document.createElement('h3');
-
-    const ruleWeight = record.value ? record.value : 0;
-
-    header.textContent = record.uid;
-    header.classList.add('ruleHighlight');
-    header.classList.add(record.broken ? 'broken' : getRuleClass(ruleWeight));
-
-    elem.href = `${window.app_base}/id?ruleUid=${encodeURIComponent(record.uid)}`;
-    elem.appendChild(header);
-
-    return elem;
+// These two functions return a string (via div.innerHTML) rather than a DOM node.
+// A string return value is required by Devbridge jQuery Autocomplete's formatResult callback setting.
+const domToHtml = function(node) {
+    const div = document.createElement('div');
+    div.appendChild(node.cloneNode(true));
+    return div.innerHTML;
 };
 
-const renderRuleType = record => {
-    if (!record.broken) {
-        return document.createTextNode(record.type);
+const formatSearchResult = function(suggestion, currentValue) {
+    const data = suggestion.data ? suggestion.data : {};
+    const category = data.category ? data.category : null;
+
+    if (category === 'IP') {
+        return domToHtml(renderIpWithCountry({
+            ip:          suggestion.value,
+            country_iso: data.country_iso ? data.country_iso : 'lh',
+        }));
     }
 
-    const elem = document.createElement('p');
-    elem.classList.add('addlight');
-    elem.textContent = record.type;
-
-    return elem;
-};
-
-const renderRuleDescription = record => {
-    const first = document.createElement('p');
-    if (record.broken) {
-        first.classList.add('inactive-rulename');
-    }
-    first.textContent = record.name;
-
-    const second = document.createElement('p');
-    second.classList.add('addlight');
-    second.textContent = record.descr;
-
-    const frag = document.createDocumentFragment();
-    frag.append(first);
-    frag.append(second);
-
-    return frag;
-};
-
-const renderRuleProportion = record => {
-    const frag = document.createDocumentFragment();
-    if (!record.broken) {
-        const proportionSpan = renderProportion(record.proportion, record.proportion_updated_at);
-        frag.append(proportionSpan);
-    }
-
-    return frag;
-};
-
-const renderRuleWeightSelector = record => {
-    const frag = document.createDocumentFragment();
-
-    if (!record.broken) {
-        const ruleWeight = record.value ? record.value : 0;
-
-        const div = document.createElement('div');
-        div.classList.add('selector');
-
-        const select = document.createElement('select');
-        select.classList.add('input');
-        select.classList.add('rulescore');
-        select.name = record.uid;
-        select.dataset.initialValue = ruleWeight.toString();
-
-        const ruleWeightKeys = mapKeys(Constants.RULE_WEIGHTS);
-        for (let i = 0; i < ruleWeightKeys.length; i++) {
-            const key = ruleWeightKeys[i];
-            const value = Constants.RULE_WEIGHTS[key];
-
-            const option = document.createElement('option');
-            option.value = key;
-            option.textContent = value.charAt(0).toUpperCase() + value.slice(1);
-            if (record.value === parseInt(key, 10)) {
-                option.selected = true;
-            }
-            select.appendChild(option);
-        }
-
-
-        div.appendChild(select);
-        frag.append(div);
-    }
-
-    return frag;
-};
-
-const renderRuleManageButtons = record => {
-    const frag = document.createDocumentFragment();
-
-    if (!record.broken) {
-        const playButton = document.createElement('button');
-        playButton.classList.add('button');
-        playButton.classList.add('dark-loader');
-        playButton.dataset.ruleUid = record.uid;
-
-        const playSpan = document.createElement('span');
-        playSpan.classList.add('icon');
-        playSpan.classList.add('ruleIcon');
-        const playImg = document.createElement('img');
-        playImg.src = `${window.app_base}/ui/images/icons/play.svg`;
-
-        playSpan.appendChild(playImg);
-        playButton.appendChild(playSpan);
-        frag.append(playButton);
-
-        const saveButton = document.createElement('button');
-        saveButton.classList.add('button');
-        saveButton.classList.add('dark-loader');
-        saveButton.classList.add('is-primary');
-        saveButton.classList.add('is-hidden');
-        saveButton.type = 'button';
-        const saveSpan = document.createElement('span');
-        saveSpan.classList.add('icon');
-        saveSpan.classList.add('ruleIcon');
-        const saveImg = document.createElement('img');
-        saveImg.src = `${window.app_base}/ui/images/icons/save.svg`;
-
-        saveSpan.appendChild(saveImg);
-        saveButton.appendChild(saveSpan);
-        frag.append(saveButton);
-    }
-
-    return frag;
+    // ID, Name, Email — all map to a user record
+    return domToHtml(renderClickableImportantUserWithScore({
+        accountid:        data.id ? data.id : null,
+        email:            suggestion.value,
+        accounttitle:     suggestion.value,
+        score:            data.score ? data.score : null,
+        score_updated_at: null,
+        is_important:     false,
+    }));
 };
 
 export {
@@ -2261,7 +2121,6 @@ export {
     //Logbook
     renderSensorErrorColumn,
     renderSensorError,
-    renderRawRequestColumn,
     renderTimeMsLogbook,
     renderEndpoint,
     renderJsonTextarea,
@@ -2284,11 +2143,6 @@ export {
     //Chart
     renderChartTooltipPart,
 
-    //Rules
-    renderRuleUid,
-    renderRuleType,
-    renderRuleDescription,
-    renderRuleProportion,
-    renderRuleWeightSelector,
-    renderRuleManageButtons,
+    //Search autocomplete
+    formatSearchResult,
 };

--- a/ui/js/parts/SearchLine.js
+++ b/ui/js/parts/SearchLine.js
@@ -1,7 +1,10 @@
-import {Loader} from './Loader.js?v=0.10.0';
-import {Tooltip} from './Tooltip.js?v=0.10.0';
-import {handleAjaxError} from './utils/ErrorHandler.js?v=0.10.0';
-import {padZero} from './utils/Date.js?v=0.10.0';
+import {Loader} from './Loader.js?v=2';
+import {Tooltip} from './Tooltip.js?v=2';
+import {handleAjaxError} from './utils/ErrorHandler.js?v=2';
+import {padZero} from './utils/Date.js?v=2';
+import {
+    formatSearchResult,
+} from './DataRenderers.js?v=2';
 
 export class SearchLine {
     constructor() {
@@ -11,7 +14,7 @@ export class SearchLine {
 
         const me = this;
         const token = document.head.querySelector('[name=\'csrf-token\'][content]').content;
-        const url = `${window.app_base}/search?token=${token}`;
+        const url = `${window.app_base}/admin/search?token=${token}`;
 
         $('#auto-complete').autocomplete({
             serviceUrl: url,
@@ -20,6 +23,8 @@ export class SearchLine {
             groupBy: 'category',
             showNoSuggestionNotice: true,
             noSuggestionNotice: 'Sorry, no matching results',
+
+            formatResult: formatSearchResult,
 
             onSelect: function(suggestion) {
                 window.open(`${window.app_base}/${suggestion.entityId}/${suggestion.id}`, '_self');
@@ -40,9 +45,10 @@ export class SearchLine {
         });
 
         // clock setup
-        //const restoreClock = this.restoreClock.bind(this);
-        //document.addEventListener('visibilitychange', restoreClock, false);
-        //setInterval(this.updateTime.bind(this), 1000);
+        const restoreClock = this.restoreClock.bind(this);
+        document.addEventListener('visibilitychange', restoreClock, false);
+
+        setInterval(this.updateTime.bind(this), 1000);
     }
 
     restoreClock() {
@@ -54,8 +60,8 @@ export class SearchLine {
         const token = document.head.querySelector('[name=\'csrf-token\'][content]').content;
 
         $.ajax({
-            url: `${window.app_base}/currentTime`,
-            type: 'GET',
+            url: `${window.app_base}/admin/currentTime`,
+            type: 'get',
             data: {token: token},
             success: onDetailsLoaded,
             error: handleAjaxError,


### PR DESCRIPTION
Closes #6

## Problem

The global search autocomplete renders all suggestion types as plain text. There is no visual differentiation between users, IPs, domains, ISPs, emails, or phones — and no contextual metadata (risk score, country) is shown alongside results.

## Solution

This PR wires up the `formatResult` hook already supported by the vendored [devbridge jQuery Autocomplete](https://github.com/devbridge/jQuery-Autocomplete) library, and enriches the backend payloads so each suggestion carries enough data to render meaningfully.

### Backend changes

**`app/Models/Search/User.php`**
- Added `event_account.score AS score` to both `searchByUserId()` and `searchByName()` queries

**`app/Models/Search/Email.php`**
- Added `LEFT JOIN event_account ON event_account.id = event_email.account_id`
- Added `event_account.score AS score` to the SELECT

**`app/Models/Search/Ip.php`**
- Added `LEFT JOIN countries ON countries.id = event_ip.country`
- Added `countries.iso AS country_iso` to the SELECT

**`app/Controllers/Admin/Search/Data.php`**
- Extended the `data` payload to also include `score` and `country_iso`; non-enriched result types receive `null` for these fields

### Frontend changes

**`ui/js/parts/DataRenderers.js`**
- Added `domToHtml(node)` — private helper that serialises a DOM node to an HTML string
- Added `formatSearchResult(suggestion, currentValue)` — dispatches by `suggestion.data.category`:
  - `IP` → renders country flag + IP via existing `renderIpWithCountry()`
  - `ID` / `Name` / `Email` → renders score badge + value via existing `renderClickableImportantUserWithScore()`

**`ui/js/parts/SearchLine.js`**
- Imports `formatSearchResult` from `DataRenderers.js`
- Passes it as `formatResult: formatSearchResult` in the autocomplete config

## Testing

- Search for a known user ID → suggestion shows value + score badge
- Search for a known user name → same
- Search for an IP → suggestion shows country flag + IP
- Search for a domain/ISP/email/phone → no regressions, renders as before
- Search with no results → "Sorry, no matching results" notice still appears